### PR TITLE
Dispatcher update

### DIFF
--- a/include/event_system/Dispatcher.h
+++ b/include/event_system/Dispatcher.h
@@ -16,49 +16,49 @@ class Subscriber;
 
 class Dispatcher {
 
-	private:
-		Dispatcher();
-		void Initialize();
+    private:
+        Dispatcher();
+        void Initialize();
 
-		static bool initialized_;
-		static bool running_;
+        static bool initialized_;
+        static bool running_;
 
-		static Dispatcher* instance_;
+        static Dispatcher* instance_;
 
-		std::deque<std::pair<EventType,std::shared_ptr<void>>>*  dispatch_events_;
-		std::map<EventType,std::list<Subscriber*>*>* mapped_events_;
+        std::deque<std::pair<EventType,std::shared_ptr<void>>>*  dispatch_events_;
+        std::map<EventType,std::list<Subscriber*>*>* mapped_events_;
 
-		static std::deque<std::pair<Subscriber*, std::shared_ptr<void>>>*  thread_queue_;
-		static std::deque<std::pair<Subscriber*, std::shared_ptr<void>>>*  nonserial_queue_;
+        static std::deque<std::pair<Subscriber*, std::shared_ptr<void>>>*  thread_queue_;
+        static std::deque<std::pair<Subscriber*, std::shared_ptr<void>>>*  nonserial_queue_;
 
-		std::deque<std::thread*>* processing_threads_; //using std::deque for constant time size() and O(1) random access
+        std::deque<std::thread*>* processing_threads_; //using std::deque for constant time size() and O(1) random access
 
-		static std::mutex dispatch_queue_mutex_;
-		static std::mutex thread_queue_mutex_;
+        static std::mutex dispatch_queue_mutex_;
+        static std::mutex thread_queue_mutex_;
         static std::mutex mapped_event_mutex_;
-		static std::condition_variable thread_signal_;
+        static std::condition_variable thread_signal_;
 
-	public:
+    public:
 
-		~Dispatcher();
-		static Dispatcher* GetInstance();
+        ~Dispatcher();
+        static Dispatcher* GetInstance();
 
-		Dispatcher(const Dispatcher&); //disallow copying
-	    Dispatcher& operator= (const Dispatcher&); //disallow copying
+        Dispatcher(const Dispatcher&); //disallow copying
+        Dispatcher& operator= (const Dispatcher&); //disallow copying
 
-		void Terminate();
+        void Terminate();
 
-		void AddEventSubscriber(Subscriber *requestor, const EventType);
-		std::list<Subscriber*> GetAllSubscribers(const void* owner);
+        void AddEventSubscriber(Subscriber *requestor, const EventType);
+        std::list<Subscriber*> GetAllSubscribers(const void* owner);
 
-		void DispatchEvent(const EventType eventID, const std::shared_ptr<void> eventData);
+        void DispatchEvent(const EventType eventID, const std::shared_ptr<void> eventData);
         void DispatchImmediate(const EventType eventID, const std::shared_ptr<void> eventData);
 
-		void Pump();
-		void NonSerialProcess();
+        void Pump();
+        void NonSerialProcess();
 
-		int QueueSize() { return static_cast<int>(thread_queue_->size()); }
+        int QueueSize() { return static_cast<int>(thread_queue_->size()); }
 
-	private:
-		static void ThreadProcess();
+    private:
+        static void ThreadProcess();
 };

--- a/include/event_system/Dispatcher.h
+++ b/include/event_system/Dispatcher.h
@@ -35,12 +35,12 @@ class Dispatcher {
 
 		static std::mutex dispatch_queue_mutex_;
 		static std::mutex thread_queue_mutex_;
+        static std::mutex mapped_event_mutex_;
 		static std::condition_variable thread_signal_;
 
 	public:
 
 		~Dispatcher();
-
 		static Dispatcher* GetInstance();
 
 		Dispatcher(const Dispatcher&); //disallow copying
@@ -52,6 +52,7 @@ class Dispatcher {
 		std::list<Subscriber*> GetAllSubscribers(const void* owner);
 
 		void DispatchEvent(const EventType eventID, const std::shared_ptr<void> eventData);
+        void DispatchImmediate(const EventType eventID, const std::shared_ptr<void> eventData);
 
 		void Pump();
 		void NonSerialProcess();

--- a/include/event_system/Subscriber.h
+++ b/include/event_system/Subscriber.h
@@ -9,39 +9,39 @@
 typedef void (SubscriptionFunction(std::shared_ptr<void>));
 
 class Subscriber {
-	public:
-		bool serialized = true;
+    public:
+        bool serialized = true;
 
-	    Subscriber(void* owner, bool serialized = true) {
-			this->owner = owner;
-			this->serialized = serialized;
-		}
-	    Subscriber(Subscriber &other) {
-			this->owner = other.owner;
-			this->method = other.method;
-			this->serialized = other.serialized;
-		}
-		
-		Subscriber(Subscriber &&other) {
-			this->owner = other.owner;
-			this->method = other.method;
-			this->serialized = other.serialized;
-		}
+        Subscriber(void* owner, bool serialized = true) {
+            this->owner = owner;
+            this->serialized = serialized;
+        }
+        Subscriber(Subscriber &other) {
+            this->owner = other.owner;
+            this->method = other.method;
+            this->serialized = other.serialized;
+        }
 
-  		// Returns strongly typed std::bind objects with typed args and returns
-		// Need a way to store this so that Dispatcher can call it
+        Subscriber(Subscriber &&other) {
+            this->owner = other.owner;
+            this->method = other.method;
+            this->serialized = other.serialized;
+        }
+
+        // Returns strongly typed std::bind objects with typed args and returns
+        // Need a way to store this so that Dispatcher can call it
 /*
-		template<typename R, typename C, typename... Args>
-		std::function<R(Args...)> bind(R (C::* func)(Args...), C& instance) {
-    		return [=](Args... args){ return (instance.*func)(args...); };
-		}
+        template<typename R, typename C, typename... Args>
+        std::function<R(Args...)> bind(R (C::* func)(Args...), C& instance) {
+            return [=](Args... args){ return (instance.*func)(args...); };
+        }
 
-		template<typename R, typename C, typename... Args>
-		std::function<R(Args...)> bind(R (C::* func)(Args...) const, C const& instance) {
-    		return [=](Args... args){ return (instance.*func)(args...); };
-		}
+        template<typename R, typename C, typename... Args>
+        std::function<R(Args...)> bind(R (C::* func)(Args...) const, C const& instance) {
+            return [=](Args... args){ return (instance.*func)(args...); };
+        }
 */
-		std::function<SubscriptionFunction> method;
+        std::function<SubscriptionFunction> method;
 
-	    void* owner;
+        void* owner;
 };

--- a/source/core/input_device.cpp
+++ b/source/core/input_device.cpp
@@ -36,11 +36,11 @@ void InputDevice::NewInput(std::shared_ptr<void> event) {
     SDL_Event* sdl_event = (SDL_Event*)event.get();
 
     if (sdl_event->type == SDL_KEYDOWN && keystates_[translations_[sdl_event->key.keysym.sym]] == false) {
-        Dispatcher::GetInstance()->DispatchEvent("EVENT_INPUT", std::make_shared<std::pair<GameEvent, bool>>(std::pair<GameEvent, bool>(translations_[sdl_event->key.keysym.sym], true)));
+        Dispatcher::GetInstance()->DispatchImmediate("EVENT_INPUT", std::make_shared<std::pair<GameEvent, bool>>(std::pair<GameEvent, bool>(translations_[sdl_event->key.keysym.sym], true)));
         keystates_[translations_[sdl_event->key.keysym.sym]] = true;
     }
     else if (sdl_event->type == SDL_KEYUP && keystates_[translations_[sdl_event->key.keysym.sym]] == true) {
-        Dispatcher::GetInstance()->DispatchEvent("EVENT_INPUT", std::make_shared<std::pair<GameEvent, bool>>(std::pair<GameEvent, bool>(translations_[sdl_event->key.keysym.sym], false)));
+        Dispatcher::GetInstance()->DispatchImmediate("EVENT_INPUT", std::make_shared<std::pair<GameEvent, bool>>(std::pair<GameEvent, bool>(translations_[sdl_event->key.keysym.sym], false)));
         keystates_[translations_[sdl_event->key.keysym.sym]] = false;
     }
 }

--- a/source/event_system/Dispatcher.cpp
+++ b/source/event_system/Dispatcher.cpp
@@ -17,6 +17,7 @@ bool Dispatcher::running_ = false;
 
 std::mutex Dispatcher::dispatch_queue_mutex_;
 std::mutex Dispatcher::thread_queue_mutex_;
+std::mutex Dispatcher::mapped_event_mutex_;
 std::condition_variable Dispatcher::thread_signal_;
 
 Dispatcher* Dispatcher::instance_ = nullptr;
@@ -70,30 +71,19 @@ void Dispatcher::Pump() {
     if (!Dispatcher::running_) return;
 
     std::lock_guard<std::mutex> dispatchLock(dispatch_queue_mutex_);
-    for (auto i : *dispatch_events_) {  // for every event
+    for (auto i : *dispatch_events_) {
+        // try is needed to handle linux map implementations
         try {
             // handle microsoft map implementation
             if (mapped_events_->count(i.first) == 0) {
                 std::cerr << "Event \"" + i.first + "\" does not apply to any Subscribers." << std::endl;
                 continue;
             }
-            for (auto it=mapped_events_->at(i.first)->begin(); it != mapped_events_->at(i.first)->end(); it++) {
-                if(*it == nullptr) {
-                    it = mapped_events_->at(i.first)->erase(it);
-                    continue;
-                }
-                std::lock_guard<std::mutex> lock(thread_queue_mutex_);  // unlocked on out-of-scope
-                if ((*it)->serialized) {
-                    thread_queue_->push_back(std::pair<Subscriber*, std::shared_ptr<void>>(*it, i.second));
-                    thread_signal_.notify_one();
-                } else {
-                    nonserial_queue_->push_back(std::pair<Subscriber*, std::shared_ptr<void>>(*it, i.second));
-                }
-          }
-      } catch (std::string msg) {
-          // catch overflow for linux
-          std::cerr << "Event \"" + i.first + "\" does not apply to any Subscribers." << std::endl;
-      }
+            DispatchImmediate(i.first, i.second);
+        } catch (std::string msg) {
+            std::cerr << "Either event \"" + i.first + "\" does not apply to any Subscribers." << std::endl;
+            std::cerr << "Or " << msg << std::endl;
+        }
     }
     dispatch_events_->clear();  // we queued them all for processing so clear the cache
 }
@@ -146,6 +136,23 @@ void Dispatcher::DispatchEvent(const EventType eventID, const std::shared_ptr<vo
     dispatch_events_->push_back(std::pair<EventType, std::shared_ptr<void>>(eventID, eventData));
 }
 
+void Dispatcher::DispatchImmediate(const EventType eventID, const std::shared_ptr<void> eventData) {
+    std::lock_guard<std::mutex> dispatchLock(mapped_event_mutex_);
+    std::lock_guard<std::mutex> lock(thread_queue_mutex_);
+    for (auto it=mapped_events_->at(eventID)->begin(); it != mapped_events_->at(eventID)->end(); it++) {
+        if(*it == nullptr) {
+            it = mapped_events_->at(eventID)->erase(it);
+            continue;
+        }
+        if ((*it)->serialized) {
+            thread_queue_->push_back(std::pair<Subscriber*, std::shared_ptr<void>>(*it, eventData));
+            thread_signal_.notify_one();
+        } else {
+            nonserial_queue_->push_back(std::pair<Subscriber*, std::shared_ptr<void>>(*it, eventData));
+        }
+    }
+}
+
 void Dispatcher::AddEventSubscriber(Subscriber *requestor, const EventType event_id) {
     if (mapped_events_->count(event_id) < 1) {
         std::cerr << "Dispatcher --->  Dynamically allocating list for EventID "
@@ -176,7 +183,7 @@ void Dispatcher::Terminate() {
 
     // There is a race condition with the condition variable and the threadpool on Microsoft implementations
     // so we need to avoid it as much a possible
-    sleep(1000);
+    sleep(500);
 
     dispatch_events_->clear();
     delete dispatch_events_;


### PR DESCRIPTION
Removed unused Dispatcher code

Added Dispatcher::DispatchImmediate() which dispatches events for immediate processing.

EVENT_INPUT events are now processed immediately.

Avoided potential deadlock on single core systems that still use the multithreaded dispatcher when dispatching an event while another thread holds the lock.

Avoided potential Dispatcher::mapped_events_ corruption on single core systems by lack of lock to preventing iterator invalidation mid context switch.

Formatting cleanup.
